### PR TITLE
HTML Dist

### DIFF
--- a/core/src/com/fdahl/apps/ponggdx/PongGdx.java
+++ b/core/src/com/fdahl/apps/ponggdx/PongGdx.java
@@ -1,11 +1,13 @@
 package com.fdahl.apps.ponggdx;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Game;
-import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.fdahl.apps.ponggdx.helper.GameType;
 import com.fdahl.apps.ponggdx.views.DifficultyScreen;
 import com.fdahl.apps.ponggdx.views.GameScreen;
 import com.fdahl.apps.ponggdx.views.MenuScreen;
+
+import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.OrthographicCamera;
 
 public class PongGdx extends Game {
 	// These are enumerations for describing each game screen
@@ -19,6 +21,7 @@ public class PongGdx extends Game {
 	public static final int HARD = 2;
 
 	public static PongGdx INSTANCE;
+	private GameType gameType;
 	private int screenWidth;
 	private int screenHeight;
 	private OrthographicCamera orthographicCamera;
@@ -26,15 +29,14 @@ public class PongGdx extends Game {
 	private MenuScreen menuScreen;
 	private DifficultyScreen difficultyScreen;
 
-	public PongGdx() {
+	public PongGdx(GameType gameType) {
 		INSTANCE = this;
+		this.gameType = gameType;
 	}
 
 	public static PongGdx getInstance() {
-		if (INSTANCE == null) {
-			INSTANCE = new PongGdx();
-		}
-
+		// Not null checking here, as we don't know the GameType to use to make a new instance.
+		// If this returns null, something serious has gone wrong.
 		return INSTANCE;
 	}
 
@@ -57,18 +59,21 @@ public class PongGdx extends Game {
 				if(menuScreen == null) {
 					menuScreen = new MenuScreen();
 				}
+				Gdx.input.setInputProcessor(menuScreen);
 				this.setScreen(menuScreen);
 				break;
 			case APPLICATION:
 				if(gameScreen == null) {
 					gameScreen = new GameScreen(orthographicCamera);
 				}
+				Gdx.input.setInputProcessor(gameScreen);
 				this.setScreen(gameScreen);
 				break;
 			case DIFFICULTY_SELECT:
 				if(difficultyScreen == null) {
 					difficultyScreen = new DifficultyScreen();
 				}
+				Gdx.input.setInputProcessor(difficultyScreen);
 				this.setScreen(difficultyScreen);
 			default:
 				break;
@@ -85,5 +90,9 @@ public class PongGdx extends Game {
 
 	public void setGameDifficulty(final int newDifficultyLevel) {
 		gameScreen.setGameDifficulty(newDifficultyLevel);
+	}
+
+	public GameType getGameType() {
+		return gameType;
 	}
 }

--- a/core/src/com/fdahl/apps/ponggdx/helper/GameType.java
+++ b/core/src/com/fdahl/apps/ponggdx/helper/GameType.java
@@ -1,0 +1,5 @@
+package com.fdahl.apps.ponggdx.helper;
+
+public enum GameType {
+    DESKTOP, HTTP;
+}

--- a/core/src/com/fdahl/apps/ponggdx/views/DifficultyScreen.java
+++ b/core/src/com/fdahl/apps/ponggdx/views/DifficultyScreen.java
@@ -3,6 +3,7 @@ package com.fdahl.apps.ponggdx.views;
 import com.fdahl.apps.ponggdx.PongGdx;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.graphics.GL20;
@@ -15,7 +16,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 
-public class DifficultyScreen implements Screen {
+public class DifficultyScreen implements Screen, InputProcessor {
     private Stage stage;
     private Skin skin;
     private Label difficultyLabel;
@@ -121,5 +122,46 @@ public class DifficultyScreen implements Screen {
     public void dispose() {
         skin.dispose();
         stage.dispose();
+    }
+
+    // The below methods are Overrides needed for the implementation of InputProcessor
+    @Override
+    public boolean keyDown(int keycode) {
+        return false;
+    }
+
+    @Override
+    public boolean keyUp(int keycode) {
+        return false;
+    }
+
+    @Override
+    public boolean keyTyped(char character) {
+        return false;
+    }
+
+    @Override
+    public boolean touchDown(int screenX, int screenY, int pointer, int button) {
+        return false;
+    }
+
+    @Override
+    public boolean touchUp(int screenX, int screenY, int pointer, int button) {
+        return false;
+    }
+
+    @Override
+    public boolean touchDragged(int screenX, int screenY, int pointer) {
+        return false;
+    }
+
+    @Override
+    public boolean mouseMoved(int screenX, int screenY) {
+        return false;
+    }
+
+    @Override
+    public boolean scrolled(float amountX, float amountY) {
+        return false;
     }
 }

--- a/core/src/com/fdahl/apps/ponggdx/views/GameScreen.java
+++ b/core/src/com/fdahl/apps/ponggdx/views/GameScreen.java
@@ -9,6 +9,7 @@ import com.fdahl.apps.ponggdx.objects.Wall;
 import com.fdahl.apps.ponggdx.helper.Const;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.ScreenAdapter;
@@ -19,7 +20,7 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.physics.box2d.Box2DDebugRenderer;
 import com.badlogic.gdx.physics.box2d.World;
 
-public class GameScreen extends ScreenAdapter {
+public class GameScreen extends ScreenAdapter implements InputProcessor {
     private OrthographicCamera camera;
     private SpriteBatch batch;
     private World world;
@@ -61,11 +62,7 @@ public class GameScreen extends ScreenAdapter {
 
         batch.setProjectionMatrix(camera.combined);
 
-        if(Gdx.input.isKeyPressed(Input.Keys.ESCAPE)) {
-            Gdx.app.exit();
-        }
-
-        if(Gdx.input.isKeyJustPressed(Input.Keys.R)) {
+        if(Gdx.input.isKeyJustPressed(Input.Keys.ESCAPE)) {
             player.setScore(0);
             playerAi.setScore(0);
             ball.reset();
@@ -124,5 +121,46 @@ public class GameScreen extends ScreenAdapter {
 
     public PlayerAI getPlayerAi() {
         return playerAi;
+    }
+
+    // The below methods are Overrides needed for the implementation of InputProcessor
+    @Override
+    public boolean keyDown(int keycode) {
+        return false;
+    }
+
+    @Override
+    public boolean keyUp(int keycode) {
+        return false;
+    }
+
+    @Override
+    public boolean keyTyped(char character) {
+        return false;
+    }
+
+    @Override
+    public boolean touchDown(int screenX, int screenY, int pointer, int button) {
+        return false;
+    }
+
+    @Override
+    public boolean touchUp(int screenX, int screenY, int pointer, int button) {
+        return false;
+    }
+
+    @Override
+    public boolean touchDragged(int screenX, int screenY, int pointer) {
+        return false;
+    }
+
+    @Override
+    public boolean mouseMoved(int screenX, int screenY) {
+        return false;
+    }
+
+    @Override
+    public boolean scrolled(float amountX, float amountY) {
+        return false;
     }
 }

--- a/core/src/com/fdahl/apps/ponggdx/views/MenuScreen.java
+++ b/core/src/com/fdahl/apps/ponggdx/views/MenuScreen.java
@@ -1,8 +1,10 @@
 package com.fdahl.apps.ponggdx.views;
 
 import com.fdahl.apps.ponggdx.PongGdx;
+import com.fdahl.apps.ponggdx.helper.GameType;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.graphics.GL20;
@@ -15,7 +17,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 
-public class MenuScreen implements Screen {
+public class MenuScreen implements Screen, InputProcessor {
     private Stage stage;
     private Skin skin;
     private Label titleLabel;
@@ -63,7 +65,10 @@ public class MenuScreen implements Screen {
         table.row().pad(30, 0, 10, 0);
         table.add(play);
         table.row().pad(10, 0, 10, 0);
-        table.add(exit);
+        // Don't add the exit button if this is an HTTP game session, as the exit call won't do anything
+        if(PongGdx.getInstance().getGameType() != GameType.HTTP) {
+            table.add(exit);
+        }
     }
 
     @Override
@@ -98,5 +103,46 @@ public class MenuScreen implements Screen {
     public void dispose() {
         skin.dispose();
         stage.dispose();
+    }
+
+    // The below methods are Overrides needed for the implementation of InputProcessor
+    @Override
+    public boolean keyDown(int keycode) {
+        return false;
+    }
+
+    @Override
+    public boolean keyUp(int keycode) {
+        return false;
+    }
+
+    @Override
+    public boolean keyTyped(char character) {
+        return false;
+    }
+
+    @Override
+    public boolean touchDown(int screenX, int screenY, int pointer, int button) {
+        return false;
+    }
+
+    @Override
+    public boolean touchUp(int screenX, int screenY, int pointer, int button) {
+        return false;
+    }
+
+    @Override
+    public boolean touchDragged(int screenX, int screenY, int pointer) {
+        return false;
+    }
+
+    @Override
+    public boolean mouseMoved(int screenX, int screenY) {
+        return false;
+    }
+
+    @Override
+    public boolean scrolled(float amountX, float amountY) {
+        return false;
     }
 }

--- a/desktop/src/com/fdahl/apps/ponggdx/desktop/DesktopLauncher.java
+++ b/desktop/src/com/fdahl/apps/ponggdx/desktop/DesktopLauncher.java
@@ -1,8 +1,10 @@
 package com.fdahl.apps.ponggdx.desktop;
 
+import com.fdahl.apps.ponggdx.PongGdx;
+import com.fdahl.apps.ponggdx.helper.GameType;
+
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
-import com.fdahl.apps.ponggdx.PongGdx;
 
 public class DesktopLauncher {
 	public static void main (String[] arg) {
@@ -14,6 +16,6 @@ public class DesktopLauncher {
 
 		config.setWindowedMode(960, 640);
 
-		new Lwjgl3Application(new PongGdx(), config);
+		new Lwjgl3Application(new PongGdx(GameType.DESKTOP), config);
 	}
 }

--- a/html/src/com/fdahl/apps/ponggdx/client/HtmlLauncher.java
+++ b/html/src/com/fdahl/apps/ponggdx/client/HtmlLauncher.java
@@ -1,9 +1,11 @@
 package com.fdahl.apps.ponggdx.client;
 
+import com.fdahl.apps.ponggdx.PongGdx;
+import com.fdahl.apps.ponggdx.helper.GameType;
+
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.backends.gwt.GwtApplication;
 import com.badlogic.gdx.backends.gwt.GwtApplicationConfiguration;
-import com.fdahl.apps.ponggdx.PongGdx;
 
 public class HtmlLauncher extends GwtApplication {
 
@@ -17,6 +19,6 @@ public class HtmlLauncher extends GwtApplication {
 
         @Override
         public ApplicationListener createApplicationListener () {
-                return new PongGdx();
+                return new PongGdx(GameType.HTTP);
         }
 }


### PR DESCRIPTION
- Added a GameType enum, which is used to tailor the menu for the desktop or HTML distributions.
- Put InputProcessors on all windows, to prevent Stage buttons from persisting into the GameScreen.